### PR TITLE
Fix for bug in deepEquals (Issue #30)

### DIFF
--- a/src/__tests__/ChartTests.js
+++ b/src/__tests__/ChartTests.js
@@ -14,6 +14,62 @@ describe('Chart re-rendering', () => {
         expect(updateRequired).toBeTruthy();
     });
 
+    it('required when data is changed in an inner object/array of the data', () => {
+        const originalData = {
+            "data": {
+                "labels": [
+                    1
+                ],
+                "datasets": [
+                    {
+                        "label": "a",
+                        "backgroundColor": "#36A2EB",
+                        "data": [
+                          122968
+                        ]
+                    },
+                    {
+                        "label": "b",
+                        "backgroundColor": "#FF6384",
+                        "data": [
+                          14738
+                        ]
+                    }
+                ]
+            },
+            "type": "bar",
+            "legend": {
+                "display": true,
+                "position": "bottom"
+            }
+        }
+        // The new data has only one data set instead of two
+        const newData = {
+            "data": {
+                "labels": [
+                    1
+                ],
+                "datasets": [
+                    {
+                        "label": "a",
+                        "backgroundColor": "#36A2EB",
+                        "data": [
+                          122968
+                        ]
+                    }
+                ]
+            },
+            "type": "bar",
+            "legend": {
+                "display": true,
+                "position": "bottom"
+            }
+        }
+        const chart = new ChartComponent(originalData);
+        const updateRequired = chart.shouldComponentUpdate(newData);
+        expect(updateRequired).toBeTruthy();
+    });
+
     it('required when chart options change', () => {
         const chart = new ChartComponent({type: 'bar', options: {hover: {mode: 'single'}}});
         const updateRequired = chart.shouldComponentUpdate({type: 'bar', options: {hover: {mode: 'label'}}});

--- a/src/__tests__/ChartTests.js
+++ b/src/__tests__/ChartTests.js
@@ -17,52 +17,30 @@ describe('Chart re-rendering', () => {
     it('required when data is changed in an inner object/array of the data', () => {
         const originalData = {
             "data": {
-                "labels": [
-                    1
-                ],
                 "datasets": [
                     {
-                        "label": "a",
-                        "backgroundColor": "#36A2EB",
                         "data": [
                           122968
                         ]
                     },
                     {
-                        "label": "b",
-                        "backgroundColor": "#FF6384",
                         "data": [
                           14738
                         ]
                     }
                 ]
-            },
-            "type": "bar",
-            "legend": {
-                "display": true,
-                "position": "bottom"
             }
         }
         // The new data has only one data set instead of two
         const newData = {
             "data": {
-                "labels": [
-                    1
-                ],
                 "datasets": [
                     {
-                        "label": "a",
-                        "backgroundColor": "#36A2EB",
                         "data": [
                           122968
                         ]
                     }
                 ]
-            },
-            "type": "bar",
-            "legend": {
-                "display": true,
-                "position": "bottom"
             }
         }
         const chart = new ChartComponent(originalData);

--- a/src/__tests__/ChartTests.js
+++ b/src/__tests__/ChartTests.js
@@ -1,4 +1,4 @@
-import ChartComponent from "../Chart";
+import ChartComponent from '../Chart';
 
 describe('Chart re-rendering', () => {
 
@@ -16,33 +16,33 @@ describe('Chart re-rendering', () => {
 
     it('required when data is changed in an inner object/array of the data', () => {
         const originalData = {
-            "data": {
-                "datasets": [
+            'data': {
+                'datasets': [
                     {
-                        "data": [
+                        'data': [
                           122968
                         ]
                     },
                     {
-                        "data": [
+                        'data': [
                           14738
                         ]
                     }
                 ]
             }
-        }
+        };
         // The new data has only one data set instead of two
         const newData = {
-            "data": {
-                "datasets": [
+            'data': {
+                'datasets': [
                     {
-                        "data": [
+                        'data': [
                           122968
                         ]
                     }
                 ]
             }
-        }
+        };
         const chart = new ChartComponent(originalData);
         const updateRequired = chart.shouldComponentUpdate(newData);
         expect(updateRequired).toBeTruthy();

--- a/src/utils/deepEqual.js
+++ b/src/utils/deepEqual.js
@@ -22,10 +22,15 @@ const deepEqual = (objA, objB) => {
 	}
 
 	let keysA = Object.keys(objA);
+	let keysB = Object.keys(objB);
+	let allKeys = keysA.concat(keysB);
 
-	// Test for A's keys different from B.
-	for (let i = 0; i < keysA.length; i++) {
-		if (!hasOwnProperty.call(objB, keysA[i])) {
+	// Verify both objects have all the keys
+	for (let i = 0; i < allKeys.length; i++) {
+		if (!hasOwnProperty.call(objB, allKeys[i])) {
+			return false;
+		}
+		if (!hasOwnProperty.call(objA, allKeys[i])) {
 			return false;
 		}
 	}


### PR DESCRIPTION
The current implementation of the `deepEquals` function only checks (recursively) if the second object has all the keys of the first object but doesn't check the other way around.
So if a key was added/removed from somewhere in the first object, this would not be considered a change.
Since that `shouldComponentUpdate` method calls `deepEquals` as follows:
`deepEqual(compareNext, compareNow)`
The effect is that if in the next props there was a change by adding/removing a key, the component won't rerender.
See issue #30 

Added a test for this case.