### PR TITLE
Keep legend length in sync with data length

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,6 +117,11 @@ class ChartComponent extends React.Component {
     // seamless transitions
     let currentDatasets = (this.chart_instance.config.data && this.chart_instance.config.data.datasets) || [];
     const nextDatasets = data.datasets || [];
+		
+		// Prevent charting of legend items that no longer exist
+    while (currentDatasets.length > nextDatasets.length) {
+      currentDatasets.pop();
+    }
 
     nextDatasets.forEach((dataset, sid) => {
       if (currentDatasets[sid] && currentDatasets[sid].data) {


### PR DESCRIPTION
If you have a line chart that's data prop has a dataset value with a variable length of objects (eg a chart with a non-constant number of legend items), the original updateChart can only account for datasets that are growing in size, not shrinking. I added a quick check to the updateChart function that pops out the extraneous array values, if necessary. This saves you from having to call redraw over and over and can make your app run much smoother.