### PR TITLE
Added support for inline plugins (see chartjs@2.5.0) and modified mix…

### DIFF
--- a/example/src/components/mix.js
+++ b/example/src/components/mix.js
@@ -79,6 +79,13 @@ const options = {
   }
 };
 
+const plugins = [{
+    afterDraw: (chartInstance, easing) => {
+        const ctx = chartInstance.chart.ctx;
+        ctx.fillText("This text drawn by a plugin", 100, 100);
+    }
+}];
+
 export default React.createClass({
   displayName: 'MixExample',
 
@@ -89,6 +96,7 @@ export default React.createClass({
         <Bar
           data={data}
           options={options}
+          plugins={plugins}
         />
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ class ChartComponent extends React.Component {
     legend: PropTypes.object,
     onElementsClick: PropTypes.func,
     options: PropTypes.object,
+    plugins: PropTypes.arrayOf(PropTypes.object),
     redraw: PropTypes.bool,
     type: PropTypes.oneOf(['doughnut', 'pie', 'line', 'bar', 'horizontalBar', 'radar', 'polarArea', 'bubble']),
     width: PropTypes.number
@@ -79,6 +80,10 @@ class ChartComponent extends React.Component {
 
     if (!isEqual(options, nextProps.options)) {
       return true;
+    }
+
+    if (!isEqual(plugins, nextProps.plugins)) {
+        return true;
     }
 
     const nextData = this.transformDataProp(nextProps)
@@ -174,14 +179,15 @@ class ChartComponent extends React.Component {
   }
 
   renderChart() {
-    const {options, legend, type, redraw} = this.props;
+    const {options, legend, type, redraw, plugins} = this.props;
     const node = ReactDOM.findDOMNode(this);
     const data = this.memoizeDataProps();
 
     this.chart_instance = new Chart(node, {
       type,
       data,
-      options
+      options,
+      plugins
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ class ChartComponent extends React.Component {
       redraw,
       type,
       options,
+      plugins,
       legend,
       height,
       width


### PR DESCRIPTION
I've added support for inline/per-chart plugins as specified in chart.js 2.5.0. See [@3363 at chartjs](https://github.com/chartjs/Chart.js/pull/3363) and [the extended plugin API](https://github.com/chartjs/Chart.js/blob/master/docs/developers/plugins.md) for specifics. It's not that much, I just added another `plugins` prop and passed it down when the chart is rendered.

I also modified the mixed data example to include a small example plugin.