### PR TITLE
Better PropType for type field

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,14 @@ class ChartComponent extends React.Component {
     options: PropTypes.object,
     plugins: PropTypes.arrayOf(PropTypes.object),
     redraw: PropTypes.bool,
-    type: PropTypes.oneOf(['doughnut', 'pie', 'line', 'bar', 'horizontalBar', 'radar', 'polarArea', 'bubble']),
+    type: function(props, propName, componentName) {
+      if(!Object.keys(Chart.controllers).find((chartType) => chartType === props[propName])){
+        return new Error(
+          'Invalid chart type `' + props[propName] + '` supplied to' +
+          ' `' + componentName + '`.'
+        );
+      }
+    },
     width: PropTypes.number,
     datasetKeyProvider: PropTypes.func
   }


### PR DESCRIPTION
If a user wants to use ChartComponent with an extended chart type, ChartComponent will currently spit out an error that the type field is invalid. With this change, we validate against the current chart types that have been added to chartjs. This includes the native chart types and any extended chart types.